### PR TITLE
Get rid of iptables submodules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "iptables"]
-	path = iptables
-	url = git://git.netfilter.org/iptables.git

--- a/examples/dump-table/dump-table.go
+++ b/examples/dump-table/dump-table.go
@@ -20,8 +20,8 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 package main
 
 import (
-	"../.."
 	"fmt"
+	"github.com/gdm85/go-libiptc"
 	"os"
 )
 

--- a/examples/lock/lock.go
+++ b/examples/lock/lock.go
@@ -20,8 +20,8 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 package main
 
 import (
-	"../.."
 	"fmt"
+	"github.com/gdm85/go-libiptc"
 	"os"
 	"time"
 )

--- a/iptc-helper.c
+++ b/iptc-helper.c
@@ -28,6 +28,8 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 #include <time.h>
 #include <sys/socket.h>
 #include <sys/un.h>
+#include <stddef.h>
+#include <unistd.h>
 
 #include "iptc-helper.h"
 

--- a/iptc-helper.h
+++ b/iptc-helper.h
@@ -17,8 +17,7 @@ along with this program; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 */
 
-#include "libiptc/libiptc.h"
-#include "iptables.h"
+#include <libiptc/libiptc.h>
 
 int has_errno();
 void reset_errno();

--- a/libiptc.go
+++ b/libiptc.go
@@ -19,11 +19,10 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
 package libiptc
 
-// #cgo CFLAGS: -I iptables/include
-// #cgo LDFLAGS: -lip4tc
+// #cgo LDFLAGS: -liptc -lip4tc -lip6tc
 // #include <stdlib.h>
-// #include "libiptc/libiptc.h"
-// #include "iptables.h"
+// #include <libiptc/libiptc.h>
+// #include <xtables.h>
 // #include "iptc-helper.h"
 import "C"
 


### PR DESCRIPTION
- Use distro specific iptables headers (e.g iptabled-dev in ubuntu) instead of submodules
- Use xtables.h instead of iptables.h
